### PR TITLE
Change back to use rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://ruby.taobao.org/'
+source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://ruby.taobao.org/
+  remote: https://rubygems.org
   specs:
     json (1.8.1)
     puma (2.8.1)


### PR DESCRIPTION
Can't access ruby.taobao.org , met 
OpenSSL::SSL::SSLError: hostname "upyun.gems.ruby-china.org" does not match the server certificate An error occurred while installing rack (1.5.2), and Bundler cannot continue.